### PR TITLE
Add validation message for repoInput

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
 			<h1><a href="?repo=[repo]" title="Click for permalink">GitHub Issue Closing Times</a></h1>
 			<form mv-action="set(repo, repoInput), set(labels, labelFilter)">
 				<p class="mv-message mv-warning mv-inline" mv-if="!(len(repoInput) >= 3 and contains(repoInput, '/'))">
-					The entered repository name is not value. Please enter it in the format <code>organisation/repository</code>
+					The entered repository name is not valid. Please enter it in the format <code>organisation/repository</code>
 				</p>
 				<div>
 					<label>Repo: <input property="repoInput" mv-default="[repoDefault]"></label>

--- a/index.html
+++ b/index.html
@@ -15,6 +15,9 @@
 		<header>
 			<h1><a href="?repo=[repo]" title="Click for permalink">GitHub Issue Closing Times</a></h1>
 			<form mv-action="set(repo, repoInput), set(labels, labelFilter)">
+				<p class="mv-message mv-warning mv-inline" mv-if="!(len(repoInput) >= 3 and contains(repoInput, '/'))">
+					The entered repository name is not value. Please enter it in the format <code>organisation/repository</code>
+				</p>
 				<div>
 					<label>Repo: <input property="repoInput" mv-default="[repoDefault]"></label>
 					<button disabled="[if(!(len(repoInput) >= 3 and contains(repoInput, '/')))]">Go!</button>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
 			<h1><a href="?repo=[repo]" title="Click for permalink">GitHub Issue Closing Times</a></h1>
 			<form mv-action="set(repo, repoInput), set(labels, labelFilter)">
 				<p class="mv-message mv-warning mv-inline" mv-if="!(len(repoInput) >= 3 and contains(repoInput, '/'))">
-					The entered repository name is not valid. Please enter it in the format <code>organisation/repository</code>
+					The entered repository name is not valid. Please enter it in the format <code>owner/repository</code>
 				</p>
 				<div>
 					<label>Repo: <input property="repoInput" mv-default="[repoDefault]"></label>


### PR DESCRIPTION
Follow-up to #8:

> Thanks, merged! In terms of UX, it would be better to (also) show an error, since just disabling controls is confusing, but this is better than nothing.

_Originally posted by @LeaVerou in https://github.com/LeaVerou/issue-closing/issues/8#issuecomment-1701321632_
            

Maybe, it would be more precise if we tested for exactly one occurance of a slash only: `(repoInput.match(/\//g)||[]).length === 1` or checked the whole `repoInput` via RegExp: `repoInput.test(/[a-z]+\/[a-z]+/)` (is that the closest and correctest we can get?)

Would you also like a message to show up when the validation is successful?